### PR TITLE
Config & logger improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A Python 3 interpreter is needed to run it.
    - *Optional* `reuse_connections`, can be `true` to enable reusing of network connections to reduce response times by avoiding connection creation overhead, or `false` to disable it. By default it is enabled.
    - *Optional* `sleep_seconds_on_get_updates_error`, which indicates the number of seconds the bot sleeps when there is an error while getting updates, to avoid hitting the server repeatedly when it has problems. By default, the bot sleeps `60` seconds.
    - *Optional* `max_error_seconds_allowed_in_normal_mode`, with the number of seconds the bot can be in normal mode while getting errors that avoid processing updates correctly. If this value is exceeded, the bot switches to process updates in pending mode, not answering to interactive actions (those under `NoPendingAction` in `BotManager`). The default is one hour.
+   - *Optional* `instance_name`, can be any string value to identify the bot instance at runtime.
 
 3. Copy the [main.py](main.py) and [bot/manager.py](bot/manager.py) files to your bot directory. Update `main.py` to use your new `BotManager` class instead of the framework one. Launch `main.py`. You now have a working bot with many features out-of-the-box! Configure them (to remove the ones you do not want, and add yours) in the `manager.py` file.
 

--- a/bot/action/core/command/__init__.py
+++ b/bot/action/core/command/__init__.py
@@ -51,7 +51,7 @@ class CommandAction(IntermediateAction):
     def __log_command_execution(event, elapsed_seconds: float = None):
         infos = [
             FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format(event.chat)).end_format(),
+                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_format).end_format(),
             FormattedText().normal("Command: {command} {args}").start_format()

--- a/bot/action/core/command/__init__.py
+++ b/bot/action/core/command/__init__.py
@@ -50,12 +50,12 @@ class CommandAction(IntermediateAction):
     @staticmethod
     def __log_command_execution(event, elapsed_seconds: float = None):
         infos = [
-            FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
+            FormattedText().normal("{command} {args}").start_format()
+                .bold(command=event.command, args=event.command_args).end_format(),
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_format).end_format(),
-            FormattedText().normal("Command: {command} {args}").start_format()
-                .bold(command=event.command, args=event.command_args).end_format()
+            FormattedText().normal("Chat: {chat}").start_format()
+                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format()
         ]
         if elapsed_seconds is not None:
             infos.append(

--- a/bot/action/core/command/throttler/shortlyrepeatedcommand.py
+++ b/bot/action/core/command/throttler/shortlyrepeatedcommand.py
@@ -49,7 +49,7 @@ class ShortlyRepeatedCommandThrottler(Throttler):
         event.logger.log(
             LOG_TAG,
             FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format(event.chat)).end_format(),
+                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_format).end_format(),
             FormattedText().normal("Command: {command} {args}").start_format()

--- a/bot/action/core/command/throttler/shortlyrepeatedcommand.py
+++ b/bot/action/core/command/throttler/shortlyrepeatedcommand.py
@@ -48,12 +48,12 @@ class ShortlyRepeatedCommandThrottler(Throttler):
     def __log_throttling(event, remaining_seconds):
         event.logger.log(
             LOG_TAG,
-            FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
+            FormattedText().normal("{command} {args}").start_format()
+                .bold(command=event.command, args=event.command_args).end_format(),
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_format).end_format(),
-            FormattedText().normal("Command: {command} {args}").start_format()
-                .bold(command=event.command, args=event.command_args).end_format(),
+            FormattedText().normal("Chat: {chat}").start_format()
+                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
             FormattedText().normal("Throttling for {seconds} seconds.").start_format()
                 .bold(seconds=remaining_seconds).end_format()
         )

--- a/bot/action/standard/config_status.py
+++ b/bot/action/standard/config_status.py
@@ -1,0 +1,63 @@
+from bot.action.core.action import Action
+from bot.action.standard.userinfo import UserStorageHandler
+from bot.action.util.format import ChatFormatter
+from bot.action.util.textformat import FormattedText
+from bot.storage import State, Config
+
+
+class ConfigStatusAction(Action):
+    def process(self, event):
+        response = FormattedText().newline().join(ConfigStatus(self.config, self.state).get_config_status())
+        self.api.send_message(response.build_message().to_chat_replying(event.message))
+
+
+class ConfigStatus:
+    def __init__(self, config: Config, state: State):
+        """
+        :param state: Used to resolve chat ids to names
+        """
+        self.config = config
+        self.user_storage_handler = UserStorageHandler.get_instance(state)
+
+    def get_config_status(self):
+        admin_user = FormattedText().normal("Admin user: {user}").start_format()\
+            .bold(user=self.__formatted_chat(self.config.admin_user_id)).end_format()
+        admin_chat = FormattedText().normal("Admin chat: {chat}").start_format()\
+            .bold(chat=self.__formatted_chat(self.config.admin_chat_id)).end_format()
+        log_chat = FormattedText().normal("Log chat: {chat}").start_format()\
+            .bold(chat=self.__formatted_chat(self.config.log_chat_id)).end_format()
+        async = FormattedText().normal("Async enabled: {bool}").start_format()\
+            .bold(bool=self.config.async()).end_format()
+        reuse_connections = FormattedText().normal("Reuse connections: {bool}").start_format()\
+            .bold(bool=self.config.reuse_connections()).end_format()
+        debug = FormattedText().normal("Debug on stdout: {bool}").start_format()\
+            .bold(bool=self.config.debug()).end_format()
+        error_tracebacks = FormattedText().normal("Send traceback on error: {bool}").start_format()\
+            .bold(bool=self.config.send_error_tracebacks()).end_format()
+        sleep_time_on_get_updates_error = FormattedText()\
+            .normal("Sleep on get_updates error: {seconds} seconds").start_format()\
+            .bold(seconds=self.config.sleep_seconds_on_get_updates_error).end_format()
+        max_error_time_in_normal_mode = FormattedText()\
+            .normal("Max error time in normal mode: {seconds} seconds").start_format()\
+            .bold(seconds=self.config.max_error_seconds_allowed_in_normal_mode).end_format()
+        instance_name = FormattedText().normal("Instance name: {name}").start_format()\
+            .bold(name=self.config.instance_name).end_format()
+        return (
+            admin_user,
+            admin_chat,
+            log_chat,
+            async,
+            reuse_connections,
+            debug,
+            error_tracebacks,
+            sleep_time_on_get_updates_error,
+            max_error_time_in_normal_mode,
+            instance_name
+        )
+
+    def __formatted_chat(self, chat_id):
+        if chat_id:
+            chat = self.user_storage_handler.get(chat_id)
+            return ChatFormatter.format_group_or_user(chat)
+        else:
+            return "<Not set (disabled)>"

--- a/bot/action/standard/config_status.py
+++ b/bot/action/standard/config_status.py
@@ -8,6 +8,10 @@ from bot.storage import State, Config
 class ConfigStatusAction(Action):
     def process(self, event):
         response = FormattedText().newline().join(ConfigStatus(self.config, self.state).get_config_status())
+        response.newline().newline()\
+            .italic("These are the current values read from storage.").newline()\
+            .italic("But please, note that most of them are being cached at startup and "
+                    "changing them will not modify bot behavior until it is restarted.")
         self.api.send_message(response.build_message().to_chat_replying(event.message))
 
 

--- a/bot/action/standard/instance.py
+++ b/bot/action/standard/instance.py
@@ -1,0 +1,9 @@
+from bot.action.core.action import Action
+from bot.action.util.textformat import FormattedText
+
+
+class InstanceAction(Action):
+    def process(self, event):
+        response = FormattedText().normal("Bot instance: {instance_name}")\
+            .start_format().bold(instance_name=self.config.instance_name).end_format()
+        self.api.send_message(response.build_message().to_chat_replying(event.message))

--- a/bot/action/util/format.py
+++ b/bot/action/util/format.py
@@ -81,6 +81,13 @@ class ChatFormatter:
         else:
             return "<" + chat.type + ">"
 
+    @staticmethod
+    def format_group_or_user(chat):
+        if GroupFormatter.is_group(chat):
+            return GroupFormatter.format(chat)
+        else:
+            return UserFormatter(chat).full_format
+
 
 class GroupFormatter:
     @staticmethod

--- a/bot/action/util/format.py
+++ b/bot/action/util/format.py
@@ -75,12 +75,21 @@ class UserFormatter:
 
 class ChatFormatter:
     @staticmethod
-    def format(chat):
-        title = chat.title
-        if title:
-            return title
+    def format_group_or_type(chat):
+        if GroupFormatter.is_group(chat):
+            return GroupFormatter.format(chat)
         else:
             return "<" + chat.type + ">"
+
+
+class GroupFormatter:
+    @staticmethod
+    def format(group):
+        return group.title
+
+    @staticmethod
+    def is_group(chat):
+        return bool(chat.title)
 
 
 class TimeFormatter:

--- a/bot/action/util/format.py
+++ b/bot/action/util/format.py
@@ -54,10 +54,13 @@ class UserFormatter:
     def full_format(self):
         """
         Returns the full name (first and last parts), and the username between brackets if the user has it.
+        If there is no info about the user, returns the user id between < and >.
         """
         formatted_user = self.full_name
         if self.user.username is not None:
             formatted_user += " [" + self.user.username + "]"
+        if not formatted_user:
+            formatted_user = "<" + str(self.user.id) + ">"
         return formatted_user
 
     @staticmethod

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,6 +2,8 @@ import time
 
 from bot.action.core.action import Action
 from bot.action.core.update import Update
+from bot.action.standard.config_status import ConfigStatus
+from bot.action.util.textformat import FormattedText
 from bot.api.api import Api
 from bot.api.telegram import TelegramBotApi
 from bot.logger.admin_logger import AdminLogger
@@ -52,12 +54,9 @@ class Bot:
             self.shutdown()
 
     def starting(self):
-        self.logger.info(
-            "Starting",
-            "async: {async}".format(async=self.config.async()),
-            "Reusing connections: {reuse_connections}".format(reuse_connections=self.config.reuse_connections()),
-            "debug: {debug}".format(debug=self.config.debug()),
-            "Error tracebacks: {error_tracebacks}".format(error_tracebacks=self.config.send_error_tracebacks())
+        self.logger.info_formatted_text(
+            FormattedText().bold("Starting"),
+            *ConfigStatus(self.config, self.state).get_config_status()
         )
 
     def main_loop(self):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -136,7 +136,7 @@ class UpdatesProcessor:
 
     def safe_log_error(self, error: Exception, *info: str):
         """Log error failing silently on error"""
-        self.__do_safe(self.logger.error(error, *info))
+        self.__do_safe(lambda: self.logger.error(error, *info))
 
     def safe_log_info(self, *info: str):
         """Log info failing silently on error"""

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -37,13 +37,7 @@ class Bot:
         self.update_processor = UpdateProcessor(self.action, self.logger)
 
     def run(self):
-        self.logger.info(
-            "Starting",
-            "async: {async}".format(async=self.config.async()),
-            "Reusing connections: {reuse_connections}".format(reuse_connections=self.config.reuse_connections()),
-            "debug: {debug}".format(debug=self.config.debug()),
-            "Error tracebacks: {error_tracebacks}".format(error_tracebacks=self.config.send_error_tracebacks())
-        )
+        self.starting()
         try:
             self.main_loop()
         except KeyboardInterrupt:
@@ -56,6 +50,15 @@ class Bot:
             raise e
         finally:
             self.shutdown()
+
+    def starting(self):
+        self.logger.info(
+            "Starting",
+            "async: {async}".format(async=self.config.async()),
+            "Reusing connections: {reuse_connections}".format(reuse_connections=self.config.reuse_connections()),
+            "debug: {debug}".format(debug=self.config.debug()),
+            "Error tracebacks: {error_tracebacks}".format(error_tracebacks=self.config.send_error_tracebacks())
+        )
 
     def main_loop(self):
         while True:

--- a/bot/logger/admin_logger.py
+++ b/bot/logger/admin_logger.py
@@ -32,15 +32,15 @@ class AdminLogger:
 
     def work_error(self, error: BaseException, work: Work, worker: Worker):
         self.__error(
-            FormattedText().normal("Worker: {worker}").start_format().bold(worker=worker.name).end_format(),
+            FormattedText().bold(ExceptionFormatter.format(error)),
             FormattedText().normal("Work: {work}").start_format().bold(work=work.name).end_format(),
-            FormattedText().bold(ExceptionFormatter.format(error))
+            FormattedText().normal("Worker: {worker}").start_format().bold(worker=worker.name).end_format()
         )
 
     def error(self, error: BaseException, action: str, *additional_info: str):
         self.__error(
-            FormattedText().normal("Action: {action}").start_format().bold(action=action).end_format(),
             FormattedText().bold(ExceptionFormatter.format(error)),
+            FormattedText().normal("Action: {action}").start_format().bold(action=action).end_format(),
             *[FormattedText().normal(info) for info in additional_info]
         )
 

--- a/bot/logger/admin_logger.py
+++ b/bot/logger/admin_logger.py
@@ -69,5 +69,8 @@ class AdminLogger:
             *[FormattedText().normal(info) for info in additional_info]
         )
 
+    def info_formatted_text(self, *info_texts: FormattedText):
+        self.__info(*info_texts)
+
     def __info(self, *texts: FormattedText):
         self.logger.log(INFO_TAG, *texts)

--- a/bot/logger/logger.py
+++ b/bot/logger/logger.py
@@ -5,7 +5,7 @@ from bot.logger.message_sender import MessageSender
 
 
 LOG_ENTRY_FORMAT = "{time} [{tag}] {text}"
-TEXT_SEPARATOR = " | "
+TEXT_SEPARATOR = "\n"
 
 
 class Logger:

--- a/bot/manager.py
+++ b/bot/manager.py
@@ -116,6 +116,8 @@ class BotManager:
                                                 AnswerAction("Up and running, sir!")
                                             ),
 
+                                            # ADMIN ACTIONS #
+
                                             CommandAction("restart").then(
                                                 AdminActionWithErrorMessage().then(
                                                     RestartAction()
@@ -146,6 +148,8 @@ class BotManager:
                                                     ConfigAction()
                                                 )
                                             ),
+
+                                            # FEATURES #
 
                                             CommandAction("settings").then(
                                                 GroupAdminAction().then(

--- a/bot/manager.py
+++ b/bot/manager.py
@@ -17,8 +17,10 @@ from bot.action.standard.answer import AnswerAction
 from bot.action.standard.benchmark import BenchmarkAction
 from bot.action.standard.chatsettings.action import ChatSettingsAction
 from bot.action.standard.config import ConfigAction
+from bot.action.standard.config_status import ConfigStatusAction
 from bot.action.standard.enterexit import GreetAction, LeaveAction
 from bot.action.standard.gapdetector import GlobalGapDetectorAction
+from bot.action.standard.instance import InstanceAction
 from bot.action.standard.internationalization import InternationalizationAction
 from bot.action.standard.logger import LoggerAction
 from bot.action.standard.perchat import PerChatAction
@@ -127,6 +129,16 @@ class BotManager:
                                             CommandAction("eval").then(
                                                 AdminActionWithErrorMessage().then(
                                                     EvalAction()
+                                                )
+                                            ),
+                                            CommandAction("configstatus").then(
+                                                AdminActionWithErrorMessage().then(
+                                                    ConfigStatusAction()
+                                                )
+                                            ),
+                                            CommandAction("instance").then(
+                                                AdminActionWithErrorMessage().then(
+                                                    InstanceAction()
                                                 )
                                             ),
                                             CommandAction("config").then(

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -75,7 +75,8 @@ class Config(Storage):
         "async": "true",
         "reuse_connections": "true",
         "sleep_seconds_on_get_updates_error": "60",
-        "max_error_seconds_allowed_in_normal_mode": "3600"
+        "max_error_seconds_allowed_in_normal_mode": "3600",
+        "instance_name": ""
     }
 
     TRUE_VALUES = ("true", "yes", "on", "1")


### PR DESCRIPTION
- all known config values are displayed at startup
- new `instance_name` config value to allow differentiating between different instances running on the same bot (not at the same time, of course (well, they could be running at the same time, but they will be getting conflict errors while polling (unless they did short polling (or they use webhooks with a load balancer in front of the instances))))
- new `/instance` command (yes, to get the instance handling the update) and `/configstatus` command (to dump current config values). They are both restricted to admin only, as they return sensitive info.
- now logger separates items with a newline, which gives a better and more legible output.
- updated some log calls to take advantage of new logger format, so they now display most relevant info on first line.