### PR TITLE
Various fixes and improvements

### DIFF
--- a/bot/action/standard/about.py
+++ b/bot/action/standard/about.py
@@ -5,9 +5,6 @@ from bot.action.core.action import Action
 from bot.action.util.textformat import FormattedText
 
 
-FRAMEWORK_TEXT = FormattedText().url(project_info.name, project_info.source_url)
-
-
 class AboutAction(Action):
     def __init__(self, project_package_name: str, author_handle: str = None, is_open_source: bool = False,
                  source_url: str = None, license_name: str = None):
@@ -21,7 +18,7 @@ class AboutAction(Action):
 
     def post_setup(self):
         bot_name = self.cache.bot_info.first_name
-        self.text = self.__build_message_text(bot_name, self.version, self.author_handle, FRAMEWORK_TEXT,
+        self.text = self.__build_message_text(bot_name, self.version, self.author_handle, self.__get_framework(),
                                               self.is_open_source, self.license_name, self.source_url)
 
     @staticmethod
@@ -45,6 +42,17 @@ class AboutAction(Action):
             .bold(bot_name=bot_name, version=version, license=license_name)\
             .normal(author=author, source_url=source_url)\
             .concat(framework=framework)\
+            .end_format()
+
+    @staticmethod
+    def __get_framework():
+        framework_name = project_info.name
+        framework_url = project_info.source_url
+        framework_version = VersionAction.get_version(framework_name)
+        return FormattedText()\
+            .normal("{url} ({version})").start_format()\
+            .url(framework_name, framework_url, name="url")\
+            .normal(version=framework_version)\
             .end_format()
 
     def process(self, event):

--- a/bot/action/standard/benchmark.py
+++ b/bot/action/standard/benchmark.py
@@ -9,10 +9,14 @@ from bot.action.util.textformat import FormattedText
 from bot.api.domain import Message
 
 
-CPU_USAGE_SAMPLE_INTERVAL_SECONDS = 5
+CPU_USAGE_SAMPLE_SECONDS = 5
 
 
 class BenchmarkAction(Action):
+    def __init__(self, cpu_usage_sample_seconds: float = CPU_USAGE_SAMPLE_SECONDS):
+        super().__init__()
+        self.cpu_usage_sample_seconds = cpu_usage_sample_seconds
+
     def process(self, event):
         (message, response), benchmark_execution_time = self.__benchmark(lambda: self._do_benchmark(event))
 
@@ -114,10 +118,10 @@ class BenchmarkAction(Action):
         system_uptime = FormattedText()\
             .normal("Uptime: {system_uptime}").start_format().bold(system_uptime=system_uptime_value).end_format()
 
-        cpu_usage_value = str(psutil.cpu_percent(interval=CPU_USAGE_SAMPLE_INTERVAL_SECONDS)) + " %"
+        cpu_usage_value = str(psutil.cpu_percent(interval=self.cpu_usage_sample_seconds)) + " %"
         cpu_usage = FormattedText()\
             .normal("CPU usage: {cpu_usage} ({sample_interval} sec. sample)").start_format()\
-            .bold(cpu_usage=cpu_usage_value).normal(sample_interval=CPU_USAGE_SAMPLE_INTERVAL_SECONDS).end_format()
+            .bold(cpu_usage=cpu_usage_value).normal(sample_interval=self.cpu_usage_sample_seconds).end_format()
 
         return FormattedText().newline().join((
             FormattedText().bold("System status"),

--- a/bot/action/standard/logger.py
+++ b/bot/action/standard/logger.py
@@ -32,6 +32,8 @@ class LoggerAction(IntermediateAction):
         self.logger = self.new_logger(self.config.log_chat_id, use_worker_pool=use_worker_pool)
         if should_use_this_logger_for_scheduler_events:
             self.__update_scheduler_callbacks()
+        # store logger in cache to allow other actions to access it outside of process()
+        self.cache.logger = self.logger
 
     def __update_scheduler_callbacks(self):
         # update scheduler callbacks to use this logger instead of the admin one

--- a/bot/multithreading/worker/pool/name_generator.py
+++ b/bot/multithreading/worker/pool/name_generator.py
@@ -7,5 +7,5 @@ class WorkerPoolNameGenerator:
     def get_name(self, number: int, is_temporal: bool = False):
         name = self.base_name + "#{current}/{max}".format(current=number, max=self.max_workers)
         if is_temporal:
-            name += "(temp,max_idle:{max_seconds_idle}s)".format(max_seconds_idle=self.max_seconds_idle)
+            name += "(max_idle:{max_seconds_idle}s)".format(max_seconds_idle=self.max_seconds_idle)
         return name


### PR DESCRIPTION
- show framework version in /about
- allow to pass the cpu_sample_usage_seconds in constructor for BenchmarkAction
- store logger in cache to be able to use it outside of process()
- commands are logged only after execution
- remove temp from temporal workers name (as they may not be temporal at all)
- document shutdown logic in scheduler api
- fix typo in manager