### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ There are no plans to support Python 2, which will be [retired soon](https://pyt
 
 1. Install `telegram-bot-framework` with pip
 
-       pip install https://github.com/alvarogzp/telegram-bot-framework.git@master
+       pip install telegram-bot-framework
 
-   or add it as a dependency to your `requirements.txt`
-
-       https://github.com/alvarogzp/telegram-bot-framework.git@master#egg=telegram-bot-framework
+   or add `telegram-bot-framework` to `install_requires` in your `setup.py`, or to your `requirements.txt` file.
 
 2. Create a `config/` dir in the base directory of your bot and add the configuration options specified in the [configuration section](#configuration) to it.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ There are no plans to support Python 2, which will be [retired soon](https://pyt
 
 4. *OPTIONAL* To enable i18n support, copy the [locales](locales) dir to your bot base directory, and run its `generate_mo.sh` script (the `run.sh` script will do it for you if you are using it). Use the `locales/` dir as the base dir for your translations. You can use and modify the helper script `update_po.sh` to extract `.po` files from your code.
 
+You can use [XtremBot](https://github.com/alvarogzp/xtrem-bot) as an example of a simple bot using this framework.
+Take a look at [World Times](https://github.com/alvarogzp/clock-bot) for a more elaborated bot.
+
 
 ## Configuration
 

--- a/bot/logger/admin_logger.py
+++ b/bot/logger/admin_logger.py
@@ -61,8 +61,8 @@ class AdminLogger:
             self.logger.log(TRACEBACK_TAG, FormattedText().code_block(traceback.format_exc()))
         except ApiException:
             # tracebacks can be very long and reach message length limit
-            # retry with a short traceback
-            self.logger.log(TRACEBACK_TAG, FormattedText().code_block(traceback.format_exc(limit=5)))
+            # retry with a shorter traceback
+            self.logger.log(TRACEBACK_TAG, FormattedText().code_block(traceback.format_exc(limit=1)))
 
     def info(self, info_text: str, *additional_info: str):
         self.__info(

--- a/publish.sh
+++ b/publish.sh
@@ -14,15 +14,14 @@ clean()
 
 build()
 {
-    python setup.py sdist
-    python setup.py bdist_wheel
+    python setup.py sdist bdist_wheel
 }
 
 sign()
 {
     for file in dist/*
     do
-        gpg --detach-sign "$file"
+        gpg --detach-sign --armor "$file"
     done
 }
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 
+TWINE_REPOSITORY="${1:-pypi}"
+
+
 cd_to_current_script_location()
 {
     current_script_location="$(dirname "$0")"
@@ -27,7 +30,8 @@ sign()
 
 publish()
 {
-    twine upload dist/*
+    echo ">> Uploading to: $TWINE_REPOSITORY"
+    twine upload --repository "$TWINE_REPOSITORY" dist/*
 }
 
 


### PR DESCRIPTION
- improvements to `publish.sh`
  - allow to choose the twine repository version
  - ensure armored output on gpg
  - do `sdist` and `bdist_wheel` in same `python setup.py` invocation
- `README` improvements
  - point to the pypi version of telegram-bot-framework
  - use xtrem-bot and clock-bot as examples in the "set-up your own bot" section
- lower the limit in admin logger traceback limited send