### PR TITLE
New ChatFormatter full_data property

### DIFF
--- a/bot/action/core/command/__init__.py
+++ b/bot/action/core/command/__init__.py
@@ -56,7 +56,7 @@ class CommandAction(IntermediateAction):
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_data).end_format(),
             FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
+                .bold(chat=ChatFormatter(event.chat).full_data).end_format(),
             FormattedText().normal("Execution time: {time}").start_format()
                 .bold(time=TimeFormatter.format(elapsed_seconds)).end_format()
         )

--- a/bot/action/core/command/throttler/shortlyrepeatedcommand.py
+++ b/bot/action/core/command/throttler/shortlyrepeatedcommand.py
@@ -53,7 +53,7 @@ class ShortlyRepeatedCommandThrottler(Throttler):
             FormattedText().normal("User: {user}").start_format()
                 .bold(user=UserFormatter(event.message.from_).full_data).end_format(),
             FormattedText().normal("Chat: {chat}").start_format()
-                .bold(chat=ChatFormatter.format_group_or_type(event.chat)).end_format(),
+                .bold(chat=ChatFormatter(event.chat).full_data).end_format(),
             FormattedText().normal("Throttling for {seconds} seconds.").start_format()
                 .bold(seconds=remaining_seconds).end_format()
         )

--- a/bot/action/util/format.py
+++ b/bot/action/util/format.py
@@ -124,13 +124,13 @@ class ChatFormatter:
     def full_data(self):
         """
         Returns all the info available for the chat in the following format:
-            title (type) [username] <id>
+            title [username] (type) <id>
         If any data is not available, it is not added.
         """
         data = [
             self.chat.title,
-            self._type(),
             self._username(),
+            self._type(),
             self._id()
         ]
         return " ".join(filter(None, data))

--- a/bot/action/util/format.py
+++ b/bot/action/util/format.py
@@ -117,6 +117,35 @@ class UserFormatter:
 
 
 class ChatFormatter:
+    def __init__(self, chat):
+        self.chat = chat
+
+    @property
+    def full_data(self):
+        """
+        Returns all the info available for the chat in the following format:
+            title (type) [username] <id>
+        If any data is not available, it is not added.
+        """
+        data = [
+            self.chat.title,
+            self._type(),
+            self._username(),
+            self._id()
+        ]
+        return " ".join(filter(None, data))
+
+    def _id(self):
+        return "<{id}>".format(id=self.chat.id)
+
+    def _type(self):
+        return "({type})".format(type=self.chat.type)
+
+    def _username(self):
+        username = self.chat.username
+        if username:
+            return "[{username}]".format(username=username)
+
     @staticmethod
     def format_group_or_type(chat):
         if GroupFormatter.is_group(chat):


### PR DESCRIPTION
Return all chat data in the following format: `title [username] (type) <id>`. The empty components (like the `title` for private chats or the `username` for private groups) are omitted.
Use it in the command and throttler log calls.