### PR TITLE
Allow to send error tracebacks to their own chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following keys are also recognised by the framework, but they are *OPTIONAL*
    - `log_chat_id`, can be set to a `chat_id` where you would like the bot to send log messages. If not set, log messages will be discarded. If set to a group, the bot must be in it.
    - `traceback_chat_id`, can have the `chat_id` you would like to receive error tracebacks on. If not set, error tracebacks won't be sent anywhere (unless `send_error_tracebacks` is set, in that case they will be sent to `admin_chat_id`). If set to a group, the bot must be in it.
    - `debug`, can have a value of `true` if you want requests and exception tracebacks to be printed on the standard output, and `false` if not. By default, they are enabled.
-   - `send_error_tracebacks`, can be `true` to send error tracebacks to `admin_chat_id` or `false` to not send them. By default they are sent.
+   - `send_error_tracebacks` *(deprecated in favor of `traceback_chat_id`)*, can be `true` to send error tracebacks to `admin_chat_id` or `false` to not send them. By default they are not sent.
    - `async`, set it to `true` to enable asynchronous support on the bot, and to `false` to disable it. By default, it is enabled.
    - `reuse_connections`, can be `true` to enable reusing of network connections to reduce response times by avoiding connection creation overhead, or `false` to disable it. By default it is enabled.
    - `scheduler_events_on_log_chat`, with a value of `true` to send scheduler event messages to log chat, and `false` to send them to admin chat. Note that initial scheduler events happening before logger is set-up are sent to admin chat regardless of this setting. By default, it is true.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following keys must be present for the bot to work properly (it will refuse 
 The following keys are also recognised by the framework, but they are *OPTIONAL*, and if not present, a default value is used:
 
    - `log_chat_id`, can be set to a `chat_id` where you would like the bot to send log messages. If not set, log messages will be discarded. If set to a group, the bot must be in it.
+   - `traceback_chat_id`, can have the `chat_id` you would like to receive error tracebacks on. If not set, error tracebacks won't be sent anywhere (unless `send_error_tracebacks` is set, in that case they will be sent to `admin_chat_id`). If set to a group, the bot must be in it.
    - `debug`, can have a value of `true` if you want requests and exception tracebacks to be printed on the standard output, and `false` if not. By default, they are enabled.
    - `send_error_tracebacks`, can be `true` to send error tracebacks to `admin_chat_id` or `false` to not send them. By default they are sent.
    - `async`, set it to `true` to enable asynchronous support on the bot, and to `false` to disable it. By default, it is enabled.

--- a/bot/action/standard/admin/config_status.py
+++ b/bot/action/standard/admin/config_status.py
@@ -24,60 +24,33 @@ class ConfigStatus:
         self.user_storage_handler = UserStorageHandler.get_instance(state)
 
     def get_config_status(self):
-        admin_user = FormattedText()\
-            .normal("Admin user: {user}").start_format()\
-            .bold(user=self.__formatted_chat(self.config.admin_user_id)).end_format()
-        admin_chat = FormattedText()\
-            .normal("Admin chat: {chat}").start_format()\
-            .bold(chat=self.__formatted_chat(self.config.admin_chat_id)).end_format()
-        log_chat = FormattedText()\
-            .normal("Log chat: {chat}").start_format()\
-            .bold(chat=self.__formatted_chat(self.config.log_chat_id)).end_format()
-        traceback_chat = FormattedText()\
-            .normal("Traceback chat: {chat}").start_format()\
-            .bold(chat=self.__formatted_chat(self.config.traceback_chat_id())).end_format()
-        async = FormattedText()\
-            .normal("Async enabled: {bool}").start_format()\
-            .bold(bool=self.config.async()).end_format()
-        reuse_connections = FormattedText()\
-            .normal("Reuse connections: {bool}").start_format()\
-            .bold(bool=self.config.reuse_connections()).end_format()
-        debug = FormattedText()\
-            .normal("Debug on stdout: {bool}").start_format()\
-            .bold(bool=self.config.debug()).end_format()
-        error_tracebacks = FormattedText()\
-            .normal("Send traceback on error (deprecated): {bool}").start_format()\
-            .bold(bool=self.config.send_error_tracebacks()).end_format()
-        scheduler_events_on_log_chat = FormattedText()\
-            .normal("Scheduler events on log chat: {bool}").start_format()\
-            .bold(bool=self.config.scheduler_events_on_log_chat()).end_format()
-        sleep_time_on_get_updates_error = FormattedText()\
-            .normal("Sleep on get_updates error: {seconds} seconds").start_format()\
-            .bold(seconds=self.config.sleep_seconds_on_get_updates_error).end_format()
-        max_error_time_in_normal_mode = FormattedText()\
-            .normal("Max error time in normal mode: {seconds} seconds").start_format()\
-            .bold(seconds=self.config.max_error_seconds_allowed_in_normal_mode).end_format()
-        max_network_workers = FormattedText()\
-            .normal("Max network workers: {number}").start_format()\
-            .bold(number=self.config.max_network_workers).end_format()
-        instance_name = FormattedText()\
-            .normal("Instance name: {name}").start_format()\
-            .bold(name=self.config.instance_name).end_format()
         return (
-            admin_user,
-            admin_chat,
-            log_chat,
-            traceback_chat,
-            async,
-            reuse_connections,
-            debug,
-            error_tracebacks,
-            scheduler_events_on_log_chat,
-            sleep_time_on_get_updates_error,
-            max_error_time_in_normal_mode,
-            max_network_workers,
-            instance_name
+            self._item("Admin user", self.__formatted_chat(self.config.admin_user_id)),
+            self._item("Admin chat", self.__formatted_chat(self.config.admin_chat_id)),
+            self._item("Log chat", self.__formatted_chat(self.config.log_chat_id)),
+            self._item("Traceback chat", self.__formatted_chat(self.config.traceback_chat_id())),
+            self._item("Async enabled", self.config.async()),
+            self._item("Reuse connections", self.config.reuse_connections()),
+            self._item("Debug on stdout", self.config.debug()),
+            self._item("Send traceback on error (deprecated)", self.config.send_error_tracebacks()),
+            self._item("Scheduler events on log chat", self.config.scheduler_events_on_log_chat()),
+            self._item("Sleep on get_updates error", self.config.sleep_seconds_on_get_updates_error, "seconds"),
+            self._item("Max error time in normal mode", self.config.max_error_seconds_allowed_in_normal_mode, "seconds"),
+            self._item("Max network workers", self.config.max_network_workers),
+            self._item("Instance name", self.config.instance_name)
         )
+
+    @staticmethod
+    def _item(label: str, value, additional_text: str = ""):
+        text = FormattedText()\
+            .normal("{label}: {value}")\
+            .start_format()\
+            .normal(label=label)\
+            .bold(value=value)\
+            .end_format()
+        if additional_text:
+            text.normal(" ").normal(additional_text)
+        return text
 
     def __formatted_chat(self, chat_id):
         if chat_id:

--- a/bot/action/standard/admin/config_status.py
+++ b/bot/action/standard/admin/config_status.py
@@ -46,7 +46,7 @@ class ConfigStatus:
             .normal("Debug on stdout: {bool}").start_format()\
             .bold(bool=self.config.debug()).end_format()
         error_tracebacks = FormattedText()\
-            .normal("Send traceback on error: {bool}").start_format()\
+            .normal("Send traceback on error (deprecated): {bool}").start_format()\
             .bold(bool=self.config.send_error_tracebacks()).end_format()
         scheduler_events_on_log_chat = FormattedText()\
             .normal("Scheduler events on log chat: {bool}").start_format()\

--- a/bot/action/standard/admin/config_status.py
+++ b/bot/action/standard/admin/config_status.py
@@ -33,6 +33,9 @@ class ConfigStatus:
         log_chat = FormattedText()\
             .normal("Log chat: {chat}").start_format()\
             .bold(chat=self.__formatted_chat(self.config.log_chat_id)).end_format()
+        traceback_chat = FormattedText()\
+            .normal("Traceback chat: {chat}").start_format()\
+            .bold(chat=self.__formatted_chat(self.config.traceback_chat_id())).end_format()
         async = FormattedText()\
             .normal("Async enabled: {bool}").start_format()\
             .bold(bool=self.config.async()).end_format()
@@ -64,6 +67,7 @@ class ConfigStatus:
             admin_user,
             admin_chat,
             log_chat,
+            traceback_chat,
             async,
             reuse_connections,
             debug,

--- a/bot/action/standard/admin/fail.py
+++ b/bot/action/standard/admin/fail.py
@@ -4,12 +4,17 @@ from bot.action.util.textformat import FormattedText
 
 class FailAction(Action):
     def process(self, event):
+        api = self.api
         error = NotARealError("simulated error")
         response = FormattedText().bold("Simulating bot error...")
-        if event.command_args == "fatal":
+        args = event.command_args.split()
+        if "fatal" in args:
             error = NotARealFatalError("simulated fatal error")
             response.newline().normal(" - ").bold("FATAL")
-        self.api.send_message(response.build_message().to_chat_replying(event.message))
+        if "async" in args:
+            api = self.api.async
+            response.newline().normal(" - ").bold("async")
+        api.send_message(response.build_message().to_chat_replying(event.message))
         raise error
 
 

--- a/bot/action/standard/admin/fail.py
+++ b/bot/action/standard/admin/fail.py
@@ -3,8 +3,14 @@ from bot.action.core.action import Action
 
 class FailAction(Action):
     def process(self, event):
+        if event.command_args == "fatal":
+            raise NotARealFatalError("simulated fatal error")
         raise NotARealError("simulated error")
 
 
 class NotARealError(Exception):
+    pass
+
+
+class NotARealFatalError(BaseException):
     pass

--- a/bot/action/standard/admin/fail.py
+++ b/bot/action/standard/admin/fail.py
@@ -1,0 +1,10 @@
+from bot.action.core.action import Action
+
+
+class FailAction(Action):
+    def process(self, event):
+        raise NotARealError("simulated error")
+
+
+class NotARealError(Exception):
+    pass

--- a/bot/action/standard/admin/fail.py
+++ b/bot/action/standard/admin/fail.py
@@ -1,11 +1,16 @@
 from bot.action.core.action import Action
+from bot.action.util.textformat import FormattedText
 
 
 class FailAction(Action):
     def process(self, event):
+        error = NotARealError("simulated error")
+        response = FormattedText().bold("Simulating bot error...")
         if event.command_args == "fatal":
-            raise NotARealFatalError("simulated fatal error")
-        raise NotARealError("simulated error")
+            error = NotARealFatalError("simulated fatal error")
+            response.newline().normal(" - ").bold("FATAL")
+        self.api.send_message(response.build_message().to_chat_replying(event.message))
+        raise error
 
 
 class NotARealError(Exception):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -27,7 +27,7 @@ class Bot:
         telegram_api = TelegramBotApi(self.config.auth_token, self.config.reuse_connections(), debug)
         self.api = Api(telegram_api, self.state)
         self.cache.bot_info = self.api.getMe()
-        self.logger = AdminLogger(self.api, self.config.admin_chat_id, debug, self.config.send_error_tracebacks())
+        self.logger = AdminLogger(self.api, self.config.admin_chat_id, debug, self.config.traceback_chat_id())
         self.scheduler = self._create_scheduler()
         self.starting()
         if self.config.async():

--- a/bot/manager.py
+++ b/bot/manager.py
@@ -20,6 +20,7 @@ from bot.action.standard.asynchronous import AsynchronousAction
 from bot.action.standard.benchmark import BenchmarkAction, WorkersAction
 from bot.action.standard.chatsettings.action import ChatSettingsAction
 from bot.action.standard.enterexit import GreetAction, LeaveAction
+from bot.action.standard.admin.fail import FailAction
 from bot.action.standard.gapdetector import GlobalGapDetectorAction
 from bot.action.standard.group_admin import GroupAdminAction
 from bot.action.standard.info.action import ChatInfoAction, UserInfoAction
@@ -166,6 +167,11 @@ class BotManager:
                                             CommandAction("workers").then(
                                                 AdminActionWithErrorMessage().then(
                                                     WorkersAction()
+                                                )
+                                            ),
+                                            CommandAction("fail").then(
+                                                AdminActionWithErrorMessage().then(
+                                                    FailAction()
                                                 )
                                             ),
 

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -92,6 +92,12 @@ class Config(Storage):
     def send_error_tracebacks(self):
         return self.__is_true("send_error_tracebacks")
 
+    def traceback_chat_id(self):
+        traceback_chat_id = self._getattr("traceback_chat_id")
+        if traceback_chat_id is None and self.send_error_tracebacks():
+            traceback_chat_id = self.admin_chat_id
+        return traceback_chat_id
+
     def async(self):
         return self.__is_true("async")
 

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -71,7 +71,7 @@ class Storage(AttributeObject):
 class Config(Storage):
     DEFAULT_VALUES = {
         "debug": "true",
-        "send_error_tracebacks": "true",
+        "send_error_tracebacks": "false",
         "async": "true",
         "reuse_connections": "true",
         "scheduler_events_on_log_chat": "true",
@@ -90,6 +90,7 @@ class Config(Storage):
         return self.__is_true("debug")
 
     def send_error_tracebacks(self):
+        """ :deprecated: Use :func:`traceback_chat_id` """
         return self.__is_true("send_error_tracebacks")
 
     def traceback_chat_id(self):


### PR DESCRIPTION
With new `traceback_chat_id` config option.
Deprecate `send_error_tracebacks` config option (and make it default to false).

New `/fail` admin command that makes the bot fail.

Improve `ConfigStatus`, simplifying its code.