### PR TITLE
More minor /about improvements and bot startup info

### DIFF
--- a/bot/action/standard/about.py
+++ b/bot/action/standard/about.py
@@ -12,11 +12,11 @@ ABOUT_FRAMEWORK_ARG = "framework"
 
 
 class ProjectInfo:
-    def __init__(self, project_package_name: str, authors: Sequence[Sequence[str]], is_open_source: bool,
+    def __init__(self, project_name: str, authors: Sequence[Sequence[str]], is_open_source: bool,
                  url: str, license_name: str, license_url: str, donation_addresses: Sequence[Sequence[str]]):
-        self.name = project_package_name
+        self.name = project_name
         self.framework = None  # type: FormattedText
-        self.project_package_name = project_package_name
+        self.project_name = project_name
         self.authors = authors
         self.is_open_source = is_open_source
         self.url = url
@@ -26,12 +26,12 @@ class ProjectInfo:
 
 
 class AboutAction(Action):
-    def __init__(self, project_package_name: str, authors: Sequence[Sequence[str]] = (), is_open_source: bool = False,
+    def __init__(self, project_name: str, authors: Sequence[Sequence[str]] = (), is_open_source: bool = False,
                  url: str = None, license_name: str = None, license_url: str = None,
                  donation_addresses: Sequence[Sequence[str]] = ()):
         super().__init__()
         self.info = ProjectInfo(
-            project_package_name, authors, is_open_source, url, license_name, license_url, donation_addresses
+            project_name, authors, is_open_source, url, license_name, license_url, donation_addresses
         )
         self.about_framework_message = self._about_framework()
 
@@ -58,7 +58,7 @@ class AboutAction(Action):
     def __about_message(self, info: ProjectInfo):
         return self.__build_message(
             info.name,
-            VersionAction.get_version(info.project_package_name),
+            VersionAction.get_version(info.project_name),
             self.__get_authors(info.authors),
             info.framework or FormattedText(),
             info.is_open_source,

--- a/bot/action/standard/about.py
+++ b/bot/action/standard/about.py
@@ -58,6 +58,7 @@ class AboutAction(Action):
     def __about_message(self, info: ProjectInfo):
         return self.__build_message(
             info.name,
+            info.project_name,
             VersionAction.get_version(info.project_name),
             self.__get_authors(info.authors),
             info.framework or FormattedText(),
@@ -116,10 +117,10 @@ class AboutAction(Action):
         return FormattedText().newline().join(texts)
 
     @staticmethod
-    def __build_message(name: str, version: str, authors: FormattedText, framework: FormattedText,
+    def __build_message(name: str, project_name: str, version: str, authors: FormattedText, framework: FormattedText,
                         is_open_source: bool, license: FormattedText, url: str, donation_addresses: FormattedText):
         text = FormattedText()\
-            .normal("{name}, version {version}.")
+            .normal("{project_name}, version {version}.")
         if framework:
             text.newline()\
                 .normal("Based on {framework}.")
@@ -129,15 +130,15 @@ class AboutAction(Action):
                 .normal("{authors}")
         if is_open_source:
             text.newline().newline()\
-                .normal("{name} is Open Source.").newline()\
+                .normal("{project_name} is Open Source.").newline()\
                 .normal("You can inspect its code, improve it and launch your own instance "
                         "(complying with the license).")
         if license:
             text.newline().newline()\
-                .normal("{name} is licensed under the {license} license.")
+                .normal("{project_name} is licensed under the {license} license.")
         if url:
             text.newline().newline()\
-                .normal("Project home:").newline()\
+                .normal("{project_name} home:").newline()\
                 .normal("{url}")
         if donation_addresses:
             text.newline().newline()\
@@ -145,7 +146,7 @@ class AboutAction(Action):
                         "please consider donating to any of the following addresses:").newline()\
                 .normal("{donation_addresses}")
         return text.start_format()\
-            .bold(name=name, version=version)\
+            .bold(name=name, project_name=project_name, version=version)\
             .normal(url=url)\
             .concat(framework=framework, authors=authors, license=license, donation_addresses=donation_addresses)\
             .end_format()\

--- a/bot/manager.py
+++ b/bot/manager.py
@@ -35,7 +35,7 @@ from bot.bot import Bot
 
 class BotManager:
     def __init__(self):
-        self.bot = Bot()
+        self.bot = Bot(project_info.name)
 
     def setup_actions(self):
         self.bot.set_action(


### PR DESCRIPTION
- about message now uses project name instead of bot current name (except for donation info, where bot name may be more user-friendly)
- `Bot` constructor can now receive a project name parameter, and if received, it will be printed on starting message, along with the version