### PR TITLE
Use async api by default

### DIFF
--- a/bot/action/core/command/throttler/shortlyrepeatedcommand/throttler.py
+++ b/bot/action/core/command/throttler/shortlyrepeatedcommand/throttler.py
@@ -47,7 +47,7 @@ class ShortlyRepeatedCommandThrottler(Throttler):
             .code_inline(remaining_seconds).normal(" seconds.")\
             .build_message()
         message.to_chat_replying(event.message)
-        self.api.send_message(message)
+        self.api.async.send_message(message)
 
     @staticmethod
     def __log_throttling(event, remaining_seconds):

--- a/bot/action/standard/admin/__init__.py
+++ b/bot/action/standard/admin/__init__.py
@@ -11,7 +11,7 @@ EXIT_STATUS_TO_HALT_BOT = 55
 class RestartAction(Action):
     def process(self, event):
         response_text = "Restarting bot...\nCommands might not work while restarting."
-        self.api.send_message(Message.create_reply(event.message, response_text))
+        self.api.no_async.send_message(Message.create_reply(event.message, response_text))
         raise KeyboardInterrupt()
 
 
@@ -25,13 +25,13 @@ class EvalAction(Action):
             response.normal("Error: {error}").start_format().bold(error=ExceptionFormatter.format(e)).end_format()
         else:
             response.normal("Result: {result}").start_format().bold(result=result).end_format()
-        self.api.send_message(response.build_message().to_chat_replying(event.message))
+        self.api.no_async.send_message(response.build_message().to_chat_replying(event.message))
 
 
 class HaltAction(Action):
     def process(self, event):
         response_text = "Bot stopped.\nYou need to launch it manually for it to work again."
-        self.api.send_message(Message.create_reply(event.message, response_text))
+        self.api.no_async.send_message(Message.create_reply(event.message, response_text))
         sys.exit(EXIT_STATUS_TO_HALT_BOT)
 
 

--- a/bot/action/standard/admin/fail.py
+++ b/bot/action/standard/admin/fail.py
@@ -4,7 +4,7 @@ from bot.action.util.textformat import FormattedText
 
 class FailAction(Action):
     def process(self, event):
-        api = self.api
+        api = self.api.no_async
         error = NotARealError("simulated error")
         response = FormattedText().bold("Simulating bot error...")
         args = event.command_args.split()

--- a/bot/action/standard/benchmark.py
+++ b/bot/action/standard/benchmark.py
@@ -64,7 +64,7 @@ class BenchmarkAction(Action):
         ))
 
     def __benchmark_send_message(self, message: Message):
-        return self.__benchmark(lambda: self.api.send_message(message))
+        return self.__benchmark(lambda: self.api.no_async.send_message(message))
 
     def __benchmark_code_execution(self):
         return self.__benchmark(lambda: [i*j*i*j for i in range(100) for j in range(100)])

--- a/bot/action/standard/group_admin.py
+++ b/bot/action/standard/group_admin.py
@@ -11,7 +11,7 @@ class GroupAdminAction(IntermediateAction):
         else:
             user = event.message.from_
             if user is not None:
-                chat_member = self.api.getChatMember(chat_id=chat.id, user_id=user.id)
+                chat_member = self.api.no_async.getChatMember(chat_id=chat.id, user_id=user.id)
                 if chat_member.status in ("creator", "administrator"):
                     self._continue(event)
                 else:

--- a/bot/action/standard/info/action.py
+++ b/bot/action/standard/info/action.py
@@ -14,7 +14,7 @@ class UserInfoAction(Action):
         if user is None:
             response = self._error_response()
         else:
-            formatter = UserInfoFormatter(self.api, user, event.chat)
+            formatter = UserInfoFormatter(self.api.no_async, user, event.chat)
             formatter.format(member_info=True)
             response = formatter.get_formatted()
         self.api.send_message(response.build_message().to_chat_replying(event.message))
@@ -66,7 +66,7 @@ class ChatInfoAction(Action):
         if chat is None:
             response = self._error_response()
         else:
-            formatter = ChatInfoFormatter(self.api, chat, self.cache.bot_info, event.message.from_)
+            formatter = ChatInfoFormatter(self.api.no_async, chat, self.cache.bot_info, event.message.from_)
             formatter.format(full_info=True)
             response = formatter.get_formatted()
         self.api.send_message(response.build_message().to_chat_replying(event.message))

--- a/bot/api/api.py
+++ b/bot/api/api.py
@@ -11,6 +11,7 @@ class Api:
         self.telegram_api = telegram_api
         self.state = state
         self.async = self
+        self.no_async = self
 
     def enable_async(self, async_api):
         self.async = async_api

--- a/bot/api/async.py
+++ b/bot/api/async.py
@@ -7,6 +7,8 @@ class AsyncApi:
     def __init__(self, api: Api, scheduler: SchedulerApi):
         self.api = api
         self.scheduler = scheduler
+        self.async = self
+        self.no_async = api
 
     def __getattr__(self, item):
         return self.__get_call_hook_for(item)

--- a/bot/manager.py
+++ b/bot/manager.py
@@ -42,233 +42,233 @@ class BotManager:
         self.bot.set_action(
             ActionGroup(
                 LoggerAction().then(
-                    GlobalGapDetectorAction().then(
+                    AsyncApiAction().then(
+                        GlobalGapDetectorAction().then(
 
-                        # # ALWAYS (or SAVE) ACTIONS # #
+                            # # ALWAYS (or SAVE) ACTIONS # #
 
-                        MessageAction().then(
-                            SaveUserAction(),
-
-                            PerChatAction().then(
-                                NoForwardedMessage().then(
-                                    VoiceMessageAction().then(
-                                        SaveVoiceAction()
-                                    )
-                                ),
-
-                                SaveMessageAction(),
-                                SavePoleAction(),
-
-                                ToggleableFeatureAction("pole").then(
-                                    LegacyPoleAction()
-                                ),
-
-                                TextMessageAction().then(
-                                    SaveHashtagsAction()
-                                )
-                            )
-                        ),
-
-                        EditedMessageAction().then(
-                            PerChatAction().then(
-                                SaveMessageAction()
-                            )
-                        ),
-
-                        # # INTERACTIVE ACTIONS # #
-
-                        NoPendingAction().then(
                             MessageAction().then(
+                                SaveUserAction(),
+
                                 PerChatAction().then(
-                                    InternationalizationAction().then(
+                                    NoForwardedMessage().then(
+                                        VoiceMessageAction().then(
+                                            SaveVoiceAction()
+                                        )
+                                    ),
 
-                                        ToggleableFeatureAction("greet").then(
-                                            GreetAction()
-                                        ),
-                                        ToggleableFeatureAction("leave").then(
-                                            LeaveAction()
-                                        ),
+                                    SaveMessageAction(),
+                                    SavePoleAction(),
 
+                                    ToggleableFeatureAction("pole").then(
+                                        LegacyPoleAction()
+                                    ),
+
+                                    TextMessageAction().then(
+                                        SaveHashtagsAction()
+                                    )
+                                )
+                            ),
+
+                            EditedMessageAction().then(
+                                PerChatAction().then(
+                                    SaveMessageAction()
+                                )
+                            ),
+
+                            # # INTERACTIVE ACTIONS # #
+
+                            NoPendingAction().then(
+                                MessageAction().then(
+                                    PerChatAction().then(
+                                        InternationalizationAction().then(
+
+                                            ToggleableFeatureAction("greet").then(
+                                                GreetAction()
+                                            ),
+                                            ToggleableFeatureAction("leave").then(
+                                                LeaveAction()
+                                            ),
+
+                                            TextMessageAction().then(
+
+                                                CommandAction("start").then(
+                                                    AnswerAction("Hello! I am " + self.bot.cache.bot_info.first_name + " and I am here to serve you.")
+                                                ),
+
+                                                CommandAction("about").then(
+                                                    AboutAction(
+                                                        project_info.name,
+                                                        authors=project_info.authors_credits,
+                                                        is_open_source=project_info.is_open_source,
+                                                        url=project_info.url,
+                                                        license_name=project_info.license_name,
+                                                        license_url=project_info.license_url,
+                                                        donation_addresses=project_info.donation_addresses
+                                                    )
+                                                ),
+
+                                                CommandAction("version").then(
+                                                    VersionAction(
+                                                        project_info.name,
+                                                        project_info.url + "/releases"
+                                                    )
+                                                ),
+
+                                                CommandAction("benchmark").then(
+                                                    AsynchronousAction("benchmark").then(
+                                                        BenchmarkAction()
+                                                    )
+                                                ),
+
+                                                CommandAction("ping").then(
+                                                    AnswerAction("Up and running, sir!")
+                                                ),
+
+                                                CommandAction("me", is_personal=True).then(
+                                                    UserInfoAction(always_sender=True)
+                                                ),
+
+                                                CommandAction("user", is_personal=True).then(
+                                                    UserInfoAction()
+                                                ),
+
+                                                CommandAction("chat").then(
+                                                    ChatInfoAction()
+                                                ),
+
+                                                # ADMIN ACTIONS #
+
+                                                CommandAction("restart").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        RestartAction()
+                                                    )
+                                                ),
+                                                CommandAction("halt").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        HaltAction()
+                                                    )
+                                                ),
+                                                CommandAction("eval").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        EvalAction()
+                                                    )
+                                                ),
+                                                CommandAction("state").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        StateAction()
+                                                    )
+                                                ),
+                                                CommandAction("config").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        ConfigStatusAction()
+                                                    )
+                                                ),
+                                                CommandAction("instance").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        InstanceAction()
+                                                    )
+                                                ),
+                                                CommandAction("workers").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        WorkersAction()
+                                                    )
+                                                ),
+                                                CommandAction("fail").then(
+                                                    AdminActionWithErrorMessage().then(
+                                                        FailAction()
+                                                    )
+                                                ),
+
+                                                # FEATURES #
+
+                                                CommandAction("settings").then(
+                                                    GroupAdminAction().then(
+                                                        ChatSettingsAction()
+                                                    )
+                                                ),
+
+                                                CommandAction("silence").then(
+                                                    GroupAdminAction().then(
+                                                        SilenceAction()
+                                                    )
+                                                ),
+
+                                                CommandAction("hashtags").then(
+                                                    ListHashtagsAction()
+                                                ),
+
+                                                CommandAction("feature").then(
+                                                    GetSetFeatureAction()
+                                                ),
+
+                                                CommandAction("polestzman").then(
+                                                    GroupAdminAction().then(
+                                                        ManagePoleTimezonesAction()
+                                                    )
+                                                ),
+
+                                                CommandAction("poles").then(
+                                                    ListPoleAction("poles")
+                                                ),
+
+                                                CommandAction("subpoles").then(
+                                                    ListPoleAction("subpoles")
+                                                ),
+
+                                                CommandAction("subsubpoles").then(
+                                                    ListPoleAction("subsubpoles")
+                                                ),
+
+                                                CommandAction("messages").then(
+                                                    ListMessageAction()
+                                                ),
+
+                                                CommandAction("message").then(
+                                                    ShowMessageAction()
+                                                ),
+
+                                                CommandAction("audios").then(
+                                                    ListVoiceAction()
+                                                ),
+
+                                                CommandAction("random").then(
+                                                    RandomChoiceAction()
+                                                )
+
+                                            )
+
+                                        )
+                                    )
+                                )
+                            ),
+
+                            # # PENDING ACTIONS # #
+
+                            PendingAction().then(
+                                MessageAction().then(
+                                    PerChatAction().then(
                                         TextMessageAction().then(
 
-                                            CommandAction("start").then(
-                                                AsyncApiAction().then(
-                                                    AnswerAction("Hello! I am " + self.bot.cache.bot_info.first_name + " and I am here to serve you.")
-                                                )
-                                            ),
-
-                                            CommandAction("about").then(
-                                                AboutAction(
-                                                    project_info.name,
-                                                    authors=project_info.authors_credits,
-                                                    is_open_source=project_info.is_open_source,
-                                                    url=project_info.url,
-                                                    license_name=project_info.license_name,
-                                                    license_url=project_info.license_url,
-                                                    donation_addresses=project_info.donation_addresses
-                                                )
-                                            ),
-
-                                            CommandAction("version").then(
-                                                VersionAction(
-                                                    project_info.name,
-                                                    project_info.url + "/releases"
-                                                )
-                                            ),
-
-                                            CommandAction("benchmark").then(
-                                                AsynchronousAction("benchmark").then(
-                                                    BenchmarkAction()
-                                                )
-                                            ),
-
                                             CommandAction("ping").then(
-                                                AnswerAction("Up and running, sir!")
+                                                AnswerAction("I'm back! Sorry for the delay...")
                                             ),
 
-                                            CommandAction("me", is_personal=True).then(
-                                                UserInfoAction(always_sender=True)
-                                            ),
-
-                                            CommandAction("user", is_personal=True).then(
-                                                UserInfoAction()
-                                            ),
-
-                                            CommandAction("chat").then(
-                                                ChatInfoAction()
-                                            ),
-
-                                            # ADMIN ACTIONS #
-
-                                            CommandAction("restart").then(
-                                                AdminActionWithErrorMessage().then(
+                                            AdminAction().then(
+                                                CommandAction("restart").then(
                                                     RestartAction()
-                                                )
-                                            ),
-                                            CommandAction("halt").then(
-                                                AdminActionWithErrorMessage().then(
+                                                ),
+                                                CommandAction("halt").then(
                                                     HaltAction()
                                                 )
-                                            ),
-                                            CommandAction("eval").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    EvalAction()
-                                                )
-                                            ),
-                                            CommandAction("state").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    StateAction()
-                                                )
-                                            ),
-                                            CommandAction("config").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    ConfigStatusAction()
-                                                )
-                                            ),
-                                            CommandAction("instance").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    InstanceAction()
-                                                )
-                                            ),
-                                            CommandAction("workers").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    WorkersAction()
-                                                )
-                                            ),
-                                            CommandAction("fail").then(
-                                                AdminActionWithErrorMessage().then(
-                                                    FailAction()
-                                                )
-                                            ),
-
-                                            # FEATURES #
-
-                                            CommandAction("settings").then(
-                                                GroupAdminAction().then(
-                                                    ChatSettingsAction()
-                                                )
-                                            ),
-
-                                            CommandAction("silence").then(
-                                                GroupAdminAction().then(
-                                                    SilenceAction()
-                                                )
-                                            ),
-
-                                            CommandAction("hashtags").then(
-                                                ListHashtagsAction()
-                                            ),
-
-                                            CommandAction("feature").then(
-                                                GetSetFeatureAction()
-                                            ),
-
-                                            CommandAction("polestzman").then(
-                                                GroupAdminAction().then(
-                                                    ManagePoleTimezonesAction()
-                                                )
-                                            ),
-
-                                            CommandAction("poles").then(
-                                                ListPoleAction("poles")
-                                            ),
-
-                                            CommandAction("subpoles").then(
-                                                ListPoleAction("subpoles")
-                                            ),
-
-                                            CommandAction("subsubpoles").then(
-                                                ListPoleAction("subsubpoles")
-                                            ),
-
-                                            CommandAction("messages").then(
-                                                ListMessageAction()
-                                            ),
-
-                                            CommandAction("message").then(
-                                                ShowMessageAction()
-                                            ),
-
-                                            CommandAction("audios").then(
-                                                ListVoiceAction()
-                                            ),
-
-                                            CommandAction("random").then(
-                                                RandomChoiceAction()
                                             )
 
                                         )
-
                                     )
                                 )
                             )
-                        ),
 
-                        # # PENDING ACTIONS # #
-
-                        PendingAction().then(
-                            MessageAction().then(
-                                PerChatAction().then(
-                                    TextMessageAction().then(
-
-                                        CommandAction("ping").then(
-                                            AnswerAction("I'm back! Sorry for the delay...")
-                                        ),
-
-                                        AdminAction().then(
-                                            CommandAction("restart").then(
-                                                RestartAction()
-                                            ),
-                                            CommandAction("halt").then(
-                                                HaltAction()
-                                            )
-                                        )
-
-                                    )
-                                )
-                            )
                         )
-
                     )
                 )
             )


### PR DESCRIPTION
By wrapping all actions with an `AsyncApiAction` in manager.

Additional modifications to support this change:
 - Add `no_async` and `async` to Api and AsyncApi, to allow easy switching between them.
 - Change `benchmark` api rtt test to not use async api
 - Update group admin check to not use async api
 - Pass no_async api to UserInfoFormatter and ChatInfoFormatter, as they need to perform sync calls

Update to not be async:
 - `restart`, `halt` and `eval` admin commands
 - `fail` command (by default)

Also made async:
 - Throttler warning messages