### PR TITLE
Case insensitive hashtags

### DIFF
--- a/bot/action/extra/hashtags.py
+++ b/bot/action/extra/hashtags.py
@@ -5,6 +5,7 @@ from bot.action.core.action import Action
 from bot.action.core.command import UnderscoredCommandBuilder
 from bot.action.core.command.usagemessage import CommandUsageMessage
 from bot.action.standard.userinfo import UserStorageHandler
+from bot.action.util.counter import case_insensitive_counter
 from bot.action.util.format import DateFormatter, UserFormatter
 from bot.action.util.textformat import FormattedText
 from bot.api.domain import Message, MessageEntityParser
@@ -196,7 +197,7 @@ class HashtagList:
 
     def grouped_by_popularity(self, max_to_return):
         hashtags_names = (hashtag.hashtag for hashtag in self.hashtags)
-        return HashtagGroup(collections.Counter(hashtags_names).most_common(max_to_return))
+        return HashtagGroup(case_insensitive_counter(hashtags_names).most_common(max_to_return))
 
     def grouped_by_user(self, max_to_return):
         hashtags_users = (hashtag.user_id for hashtag in self.hashtags)

--- a/bot/action/util/counter.py
+++ b/bot/action/util/counter.py
@@ -1,0 +1,21 @@
+import collections
+
+
+def case_insensitive_counter(elements):
+    counter = collections.Counter(elements)
+
+    elements_lower = {}
+    for element in counter:
+        element_lower = element.lower()
+        elements_lower.setdefault(element_lower, []).append(element)
+
+    for _, cases in elements_lower.items():
+        if len(cases) > 1:
+            most_used_case = max(cases, key=lambda case: counter[case])
+            total_occurrences = sum((counter[case] for case in cases))
+            counter[most_used_case] = total_occurrences
+            for case in cases:
+                if case != most_used_case:
+                    del counter[case]
+
+    return counter

--- a/bot/action/util/counter.py
+++ b/bot/action/util/counter.py
@@ -11,8 +11,8 @@ def case_insensitive_counter(elements):
 
     for _, cases in elements_lower.items():
         if len(cases) > 1:
-            most_used_case = max(cases, key=lambda case: counter[case])
-            total_occurrences = sum((counter[case] for case in cases))
+            most_used_case = max(cases, key=counter.get)
+            total_occurrences = sum(map(counter.get, cases))
             counter[most_used_case] = total_occurrences
             for case in cases:
                 if case != most_used_case:


### PR DESCRIPTION
- Implement a **case-insensitive counter** which finds and keeps the most-repeated version of values that differ only in case.
  - That way, for case-insensitive groupings, we don't have to use lowered (or uppered) versions of the repeated elements, and can instead show the most common appearance of it.
- Use the case-insensitive counter when grouping hashtags by popularity.

Closes #159 