### PR TITLE
Improve hashtags time interval filtering

### DIFF
--- a/bot/action/extra/hashtags.py
+++ b/bot/action/extra/hashtags.py
@@ -1,6 +1,8 @@
 import collections
 import time
 
+import pytimeparse
+
 from bot.action.core.action import Action
 from bot.action.core.command import UnderscoredCommandBuilder
 from bot.action.core.command.usagemessage import CommandUsageMessage
@@ -106,9 +108,8 @@ class ListHashtagsAction(Action):
             return 30 * 24 * 3600  # 30 days
         elif interval == "year":
             return 365 * 24 * 3600  # 365 days
-        elif interval[-1] == "d" and interval[:-1].isnumeric():
-            return int(interval[:-1]) * 24 * 3600
-        return None
+        else:
+            return pytimeparse.parse(interval)
 
     @staticmethod
     def get_response_help(event, help_args):

--- a/bot/action/extra/hashtags.py
+++ b/bot/action/extra/hashtags.py
@@ -138,7 +138,7 @@ class ListHashtagsAction(Action):
 
     def get_response_popular(self, event, hashtags, time_interval_in_seconds, number_of_hashtags_to_display, raw_interval):
         if time_interval_in_seconds != HASHTAGS_NO_FILTER_BY_TIME:
-            oldest_requested_hashtag = int(time.time()) - time_interval_in_seconds
+            oldest_requested_hashtag = event.message.date - time_interval_in_seconds
             hashtags = hashtags.filter_older_than(oldest_requested_hashtag)
             title = FormattedText().normal("Most popular hashtags during the last {interval}:").start_format().bold(interval=raw_interval).end_format()
         else:

--- a/bot/action/extra/hashtags.py
+++ b/bot/action/extra/hashtags.py
@@ -1,5 +1,4 @@
 import collections
-import time
 
 import pytimeparse
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'sqlite-framework',
         'requests',
         'pytz',
-        'psutil'
+        'psutil',
+        'pytimeparse'
     ],
 
     python_requires='>=3',


### PR DESCRIPTION
- Use https://github.com/wroberts/pytimeparse, which supports from seconds to weeks human intervals.
- Use message date instead of bot time to determine filtering timestamp.

Closes #158 