### PR TITLE
Lower message retention to reduce server pressure (1/2)

### DIFF
--- a/bot/action/extra/messages/storage.py
+++ b/bot/action/extra/messages/storage.py
@@ -3,8 +3,8 @@ import json
 from bot.action.extra.messages.mapper import StoredMessageMapper
 from bot.action.extra.messages.operations import MessageList, MessageIdOperations
 
-MIN_MESSAGES_TO_KEEP = 1000
-MAX_MESSAGES_TO_KEEP = 10000
+MIN_MESSAGES_TO_KEEP = 50
+MAX_MESSAGES_TO_KEEP = 100
 
 
 class MessageStorageHandler:

--- a/bot/action/extra/messages/storage.py
+++ b/bot/action/extra/messages/storage.py
@@ -3,8 +3,8 @@ import json
 from bot.action.extra.messages.mapper import StoredMessageMapper
 from bot.action.extra.messages.operations import MessageList, MessageIdOperations
 
-MIN_MESSAGES_TO_KEEP = 50
-MAX_MESSAGES_TO_KEEP = 100
+MIN_MESSAGES_TO_KEEP = 10
+MAX_MESSAGES_TO_KEEP = 20
 
 
 class MessageStorageHandler:


### PR DESCRIPTION
This is the first part of a series of fixes for XtremBot recent errors due to excessive storage pressure.

These changes should only affect users of the `/messages` command.

Here is a detailed explanation of the changes and their consequences:
- First, I'm **drastically reducing message retention**.
After this change is live, I'll give some time for the bot to catch up and reduce retention on the different chats.
During this time, `/messages` command usefulness will be very limited (only to the most recent dozens of messages).
- Then, I will update default settings to **not keep messages by default**.
Chats that still want to use `/messages` will need to enable it (if they haven't done before) with the `/settings set store_messages on` command.
- Finally, I will **raise again message retention**.
As less chats will now be using this feature, we can increase storage pressure to deliver a better experience.