### PR TITLE
Disable `/messages` by default (2/2)

### DIFF
--- a/bot/action/extra/messages/storage.py
+++ b/bot/action/extra/messages/storage.py
@@ -3,8 +3,8 @@ import json
 from bot.action.extra.messages.mapper import StoredMessageMapper
 from bot.action.extra.messages.operations import MessageList, MessageIdOperations
 
-MIN_MESSAGES_TO_KEEP = 10
-MAX_MESSAGES_TO_KEEP = 20
+MIN_MESSAGES_TO_KEEP = 1000
+MAX_MESSAGES_TO_KEEP = 5000
 
 
 class MessageStorageHandler:

--- a/bot/action/standard/chatsettings/__init__.py
+++ b/bot/action/standard/chatsettings/__init__.py
@@ -18,7 +18,7 @@ class ChatSettings:
     # List of chat settings
     # To add one: SETTING = add_setting("name", "default_value")
     LANGUAGE = add_setting("language", "en")
-    STORE_MESSAGES = add_setting("store_messages", "on")
+    STORE_MESSAGES = add_setting("store_messages", "off")
     OVERRIDE_MESSAGES_OPT_OUT = add_setting("override_messages_opt_out", "off")
     THROTTLING_SECONDS = add_setting("throttling_seconds", 15, Codecs.INT)
 


### PR DESCRIPTION
To remove server pressure.
Group admins willing to keep using it can enable it using `/settings set store_messages on`.

Restore previous message retention values.