### PR TITLE
More flexible message retention

### DIFF
--- a/bot/action/extra/messages/__init__.py
+++ b/bot/action/extra/messages/__init__.py
@@ -20,7 +20,7 @@ def is_store_messages_enabled(event):
 class SaveMessageAction(Action):
     def process(self, event):
         if is_store_messages_enabled(event):
-            storage_handler = MessageStorageHandler(event)
+            storage_handler = MessageStorageHandler(self.config, event)
             storage_handler.save_message(event.message)
             storage_handler.delete_old_messages()
 

--- a/bot/action/extra/messages/storage.py
+++ b/bot/action/extra/messages/storage.py
@@ -3,12 +3,13 @@ import json
 from bot.action.extra.messages.mapper import StoredMessageMapper
 from bot.action.extra.messages.operations import MessageList, MessageIdOperations
 
-MIN_MESSAGES_TO_KEEP = 1000
-MAX_MESSAGES_TO_KEEP = 5000
+DEFAULT_MESSAGES_KEEP_MIN = 1000
+DEFAULT_MESSAGES_KEEP_MAX = 5000
 
 
 class MessageStorageHandler:
-    def __init__(self, event):
+    def __init__(self, config, event):
+        self.config = config.get_for("messages")
         self.state = event.state.get_for("messages")
 
     def get_stored_messages(self):
@@ -21,8 +22,10 @@ class MessageStorageHandler:
 
     def delete_old_messages(self):
         stored_ids = self.state.list_keys()
-        if len(stored_ids) > MAX_MESSAGES_TO_KEEP:
-            number_of_messages_to_delete = len(stored_ids) - MIN_MESSAGES_TO_KEEP
+        max_messages_to_keep = self.config.get_value("keep_max", DEFAULT_MESSAGES_KEEP_MAX)
+        if len(stored_ids) > max_messages_to_keep:
+            min_messages_to_keep = self.config.get_value("keep_min", DEFAULT_MESSAGES_KEEP_MIN)
+            number_of_messages_to_delete = len(stored_ids) - min_messages_to_keep
             ids_to_delete = MessageIdOperations.sorted(stored_ids, keep_only_first=number_of_messages_to_delete)
             self.__delete_messages(ids_to_delete)
 


### PR DESCRIPTION
Message retention limits have already been the cause of some releases. Allow to set their values via config so that there is no longer need to publish a new release to update them.

TODO: Review and check there are no more uses of `MessageStorageHandler` that need to be updated.